### PR TITLE
chore: update GitHub Actions configuration and classifiers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,10 +4,10 @@
 __pycache__/
 *.py[cod]
 *$py.class
- 
+
 # C extensions
 *.so
- 
+
 # Distribution / packaging
 .Python
 build/
@@ -25,18 +25,18 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
- 
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 MANIFEST
 *.spec
- 
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
- 
+
 # Unit test / coverage reports
 htmlcov/
 .tox/
@@ -47,58 +47,58 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
- 
+
 # Translations
 *.mo
 *.pot
- 
+
 # Django stuff:
 *.log
 local_settings.py
- 
+
 # Flask stuff:
 instance/
 .webassets-cache
- 
+
 # Scrapy stuff:
 .scrapy
- 
+
 # Sphinx documentation
 docs/_build/
- 
+
 # PyBuilder
 target/
- 
+
 # Jupyter Notebook
 .ipynb_checkpoints
- 
+
 # pyenv
 .python-version
- 
+
 # celery beat schedule file
 celerybeat-schedule
- 
+
 # SageMath parsed files
 *.sage.py
- 
+
 # Environments
 .env
 .venv
 env/
 venv/
 ENV/
- 
+
 # Spyder project settings
 .spyderproject
 .spyproject
- 
+
 # Rope project settings
 .ropeproject
- 
+
 # mkdocs documentation
 /site
- 
+
 # mypy
 .mypy_cache/
- 
+
 .idea

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,15 +6,15 @@ on:
 jobs:
   build:
     name: Publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: '3.11'
     - name: Install twine
       run: >-
         python -m
@@ -31,4 +31,3 @@ jobs:
         password: ${{ secrets.pypi_password }}
         # repository_url: https://pypi.org/legacy/
 
-      

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,10 @@
 __pycache__/
 *.py[cod]
 *$py.class
- 
+
 # C extensions
 *.so
- 
+
 # Distribution / packaging
 .Python
 build/
@@ -25,18 +25,18 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
- 
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 MANIFEST
 *.spec
- 
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
- 
+
 # Unit test / coverage reports
 htmlcov/
 .tox/
@@ -47,59 +47,58 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
- 
+
 # Translations
 *.mo
 *.pot
- 
+
 # Django stuff:
 *.log
 local_settings.py
- 
+
 # Flask stuff:
 instance/
 .webassets-cache
- 
+
 # Scrapy stuff:
 .scrapy
- 
+
 # Sphinx documentation
 docs/_build/
- 
+
 # PyBuilder
 target/
- 
+
 # Jupyter Notebook
 .ipynb_checkpoints
- 
+
 # pyenv
 .python-version
- 
+
 # celery beat schedule file
 celerybeat-schedule
- 
+
 # SageMath parsed files
 *.sage.py
- 
+
 # Environments
 .env
 .venv
 env/
 venv/
 ENV/
- 
+
 # Spyder project settings
 .spyderproject
 .spyproject
- 
+
 # Rope project settings
 .ropeproject
- 
+
 # mkdocs documentation
 /site
- 
+
 # mypy
 .mypy_cache/
- 
+
 .idea
-.github/

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,20 @@ def get_install_requires():
     return requires
 
 
+classifiers = [
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Console :: Curses',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+]
+
 setup(
     name='codosdk',
     version=VERSION,
@@ -44,16 +58,7 @@ setup(
     long_description='SDK of the operation and maintenance script logs operate',
     include_package_data=True,
     data_files=get_data_files(),
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console :: Curses',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.9'
-    ],
+    python_requires=">=3.6",
+    classifiers=classifiers,
     platforms='any'
 )


### PR DESCRIPTION
- Add a new file `.github/dependabot.yml`
- Schedule a weekly dependabot check for all github actions files
- Change the runs-on value for the `build` job in `.github/workflows/pypi.yml` from `ubuntu-18.04` to `ubuntu-latest`
- Update the `actions/checkout` in `.github/workflows/pypi.yml` from `@master` to `@v4`
- Change the Python version used in the `build` job in `.github/workflows/pypi.yml` from `3.9` to `3.11`
- Update the `actions/setup-python` in `.github/workflows/pypi.yml` from `@v1` to `@v5`
- Add and modify classifiers for the `setup.py` file