### PR TITLE
chore: update PyPI publishing workflow to use token authentication

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,7 +25,7 @@ jobs:
       run: >-
         python setup.py sdist
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
- Update the PyPI workflow action to use the `release/v1` version
- The publishing to PyPI now uses a token instead of a password